### PR TITLE
Persist expenses in CSV repository

### DIFF
--- a/data/expenses.csv
+++ b/data/expenses.csv
@@ -1,0 +1,9 @@
+paid,description,amount,dueDay,remaining
+true,Banco,1000.00,5,0.00
+false,Cartão Nubank,1683.43,10,296.85
+false,Emprestimo,921.68,8,0.00
+false,Cartão Itaú,1500.00,15,0.00
+true,Vivo,80.00,21,0.00
+false,Internet,150.00,18,0.00
+false,Farmácia,100.00,20,0.00
+false,Mercado Pago,1120.66,28,0.00

--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,15 @@
 		<java.version>17</java.version>
 	</properties>
 	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-validation</artifactId>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/finance/dashboard/controller/FinanceController.java
+++ b/src/main/java/com/finance/dashboard/controller/FinanceController.java
@@ -1,13 +1,19 @@
 package com.finance.dashboard.controller;
 
 import com.finance.dashboard.model.Expense;
+import com.finance.dashboard.model.ExpenseRequest;
 import com.finance.dashboard.model.ExpenseSummary;
 import com.finance.dashboard.service.FinanceService;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -23,6 +29,12 @@ public class FinanceController {
     @GetMapping("/expenses")
     public List<Expense> getExpenses() {
         return financeService.listExpenses();
+    }
+
+    @PostMapping("/expenses")
+    @ResponseStatus(HttpStatus.CREATED)
+    public Expense createExpense(@Valid @RequestBody ExpenseRequest request) {
+        return financeService.registerExpense(request.toExpense());
     }
 
     @GetMapping("/summary")

--- a/src/main/java/com/finance/dashboard/model/Expense.java
+++ b/src/main/java/com/finance/dashboard/model/Expense.java
@@ -1,6 +1,7 @@
 package com.finance.dashboard.model;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 public class Expense {
     private final boolean paid;
@@ -11,10 +12,10 @@ public class Expense {
 
     public Expense(boolean paid, String description, BigDecimal amount, int dueDay, BigDecimal remaining) {
         this.paid = paid;
-        this.description = description;
-        this.amount = amount;
+        this.description = Objects.requireNonNull(description, "description must not be null");
+        this.amount = Objects.requireNonNull(amount, "amount must not be null");
         this.dueDay = dueDay;
-        this.remaining = remaining;
+        this.remaining = remaining == null ? BigDecimal.ZERO : remaining;
     }
 
     public boolean isPaid() {

--- a/src/main/java/com/finance/dashboard/model/ExpenseRequest.java
+++ b/src/main/java/com/finance/dashboard/model/ExpenseRequest.java
@@ -1,0 +1,34 @@
+package com.finance.dashboard.model;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+public record ExpenseRequest(
+    @NotNull(message = "Status de pagamento é obrigatório")
+    Boolean paid,
+
+    @NotBlank(message = "Descrição é obrigatória")
+    String description,
+
+    @NotNull(message = "Valor é obrigatório")
+    @DecimalMin(value = "0.00", inclusive = false, message = "Valor deve ser maior que zero")
+    BigDecimal amount,
+
+    @Min(value = 1, message = "Dia de vencimento deve ser entre 1 e 31")
+    @Max(value = 31, message = "Dia de vencimento deve ser entre 1 e 31")
+    int dueDay,
+
+    @NotNull(message = "Valor restante é obrigatório")
+    @DecimalMin(value = "0.00", message = "Valor restante não pode ser negativo")
+    BigDecimal remaining
+) {
+    public Expense toExpense() {
+        boolean isPaid = Boolean.TRUE.equals(paid);
+        BigDecimal normalizedRemaining = isPaid ? BigDecimal.ZERO : remaining;
+        return new Expense(isPaid, description, amount, dueDay, normalizedRemaining);
+    }
+}

--- a/src/main/java/com/finance/dashboard/repository/CsvExpenseRepository.java
+++ b/src/main/java/com/finance/dashboard/repository/CsvExpenseRepository.java
@@ -1,0 +1,178 @@
+package com.finance.dashboard.repository;
+
+import com.finance.dashboard.model.Expense;
+import jakarta.annotation.PostConstruct;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class CsvExpenseRepository implements ExpenseRepository {
+
+    private static final String[] HEADER = {"paid", "description", "amount", "dueDay", "remaining"};
+    private final Path csvPath;
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+    public CsvExpenseRepository() {
+        this(Paths.get("data", "expenses.csv"));
+    }
+
+    CsvExpenseRepository(Path csvPath) {
+        this.csvPath = csvPath;
+    }
+
+    @PostConstruct
+    void initializeRepository() {
+        lock.writeLock().lock();
+        try {
+            Path parent = csvPath.getParent();
+            if (parent != null && Files.notExists(parent)) {
+                Files.createDirectories(parent);
+            }
+            if (Files.notExists(csvPath)) {
+                try (BufferedWriter writer = Files.newBufferedWriter(csvPath, StandardCharsets.UTF_8)) {
+                    writer.write(String.join(",", HEADER));
+                    writer.newLine();
+                }
+            }
+        } catch (IOException exception) {
+            throw new IllegalStateException("Failed to initialize expenses CSV file", exception);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public List<Expense> findAll() {
+        lock.readLock().lock();
+        try {
+            return readAllInternal().stream()
+                .sorted(Comparator.comparingInt(Expense::getDueDay))
+                .collect(Collectors.toUnmodifiableList());
+        } catch (IOException exception) {
+            throw new IllegalStateException("Failed to read expenses from CSV file", exception);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public void save(Expense expense) {
+        Objects.requireNonNull(expense, "expense must not be null");
+        lock.writeLock().lock();
+        try {
+            List<Expense> expenses = readAllInternal();
+            expenses.add(expense);
+            writeAll(expenses);
+        } catch (IOException exception) {
+            throw new IllegalStateException("Failed to save expense to CSV file", exception);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public void saveAll(List<Expense> expenses) {
+        Objects.requireNonNull(expenses, "expenses must not be null");
+        lock.writeLock().lock();
+        try {
+            writeAll(expenses);
+        } catch (IOException exception) {
+            throw new IllegalStateException("Failed to persist expenses to CSV file", exception);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private Expense toExpense(String line) {
+        List<String> columns = parseCsvLine(line);
+        if (columns.size() != HEADER.length) {
+            throw new IllegalStateException("Invalid expense line: " + line);
+        }
+        boolean paid = Boolean.parseBoolean(columns.get(0));
+        String description = columns.get(1);
+        BigDecimal amount = new BigDecimal(columns.get(2));
+        int dueDay = Integer.parseInt(columns.get(3));
+        BigDecimal remaining = new BigDecimal(columns.get(4));
+        return new Expense(paid, description, amount, dueDay, remaining);
+    }
+
+    private void writeAll(List<Expense> expenses) throws IOException {
+        List<Expense> sorted = expenses.stream()
+            .sorted(Comparator.comparingInt(Expense::getDueDay).thenComparing(Expense::getDescription))
+            .toList();
+        try (BufferedWriter writer = Files.newBufferedWriter(csvPath, StandardCharsets.UTF_8)) {
+            writer.write(String.join(",", HEADER));
+            writer.newLine();
+            for (Expense expense : sorted) {
+                writer.write(formatExpense(expense));
+                writer.newLine();
+            }
+        }
+    }
+
+    private List<Expense> readAllInternal() throws IOException {
+        try (BufferedReader reader = Files.newBufferedReader(csvPath, StandardCharsets.UTF_8)) {
+            return reader.lines()
+                .skip(1)
+                .filter(line -> !line.isBlank())
+                .map(this::toExpense)
+                .collect(Collectors.toCollection(ArrayList::new));
+        }
+    }
+
+    private String formatExpense(Expense expense) {
+        return String.join(",",
+            Boolean.toString(expense.isPaid()),
+            escape(expense.getDescription()),
+            expense.getAmount().setScale(2, RoundingMode.HALF_UP).toPlainString(),
+            Integer.toString(expense.getDueDay()),
+            expense.getRemaining().setScale(2, RoundingMode.HALF_UP).toPlainString()
+        );
+    }
+
+    private String escape(String value) {
+        if (value.contains(",") || value.contains("\n") || value.contains("\"")) {
+            return "\"" + value.replace("\"", "\"\"") + "\"";
+        }
+        return value;
+    }
+
+    private List<String> parseCsvLine(String line) {
+        List<String> values = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+        for (int index = 0; index < line.length(); index++) {
+            char character = line.charAt(index);
+            if (character == '"') {
+                if (inQuotes && index + 1 < line.length() && line.charAt(index + 1) == '"') {
+                    current.append('"');
+                    index++;
+                } else {
+                    inQuotes = !inQuotes;
+                }
+            } else if (character == ',' && !inQuotes) {
+                values.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(character);
+            }
+        }
+        values.add(current.toString());
+        return values;
+    }
+}

--- a/src/main/java/com/finance/dashboard/repository/ExpenseRepository.java
+++ b/src/main/java/com/finance/dashboard/repository/ExpenseRepository.java
@@ -1,0 +1,12 @@
+package com.finance.dashboard.repository;
+
+import com.finance.dashboard.model.Expense;
+import java.util.List;
+
+public interface ExpenseRepository {
+    List<Expense> findAll();
+
+    void save(Expense expense);
+
+    void saveAll(List<Expense> expenses);
+}

--- a/src/main/java/com/finance/dashboard/service/FinanceService.java
+++ b/src/main/java/com/finance/dashboard/service/FinanceService.java
@@ -2,6 +2,7 @@ package com.finance.dashboard.service;
 
 import com.finance.dashboard.model.Expense;
 import com.finance.dashboard.model.ExpenseSummary;
+import com.finance.dashboard.repository.ExpenseRepository;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
@@ -10,22 +11,24 @@ import org.springframework.stereotype.Service;
 @Service
 public class FinanceService {
 
-    private final List<Expense> expenses = List.of(
-        new Expense(true, "Banco", new BigDecimal("1000.00"), 5, BigDecimal.ZERO),
-        new Expense(false, "Cartão Nubank", new BigDecimal("1683.43"), 10, new BigDecimal("296.85")),
-        new Expense(false, "Emprestimo", new BigDecimal("921.68"), 8, BigDecimal.ZERO),
-        new Expense(false, "Cartão Itaú", new BigDecimal("1500.00"), 15, BigDecimal.ZERO),
-        new Expense(true, "Vivo", new BigDecimal("80.00"), 21, BigDecimal.ZERO),
-        new Expense(false, "Internet", new BigDecimal("150.00"), 18, BigDecimal.ZERO),
-        new Expense(false, "Farmácia", new BigDecimal("100.00"), 20, BigDecimal.ZERO),
-        new Expense(false, "Mercado Pago", new BigDecimal("1120.66"), 28, BigDecimal.ZERO)
-    );
+    private final ExpenseRepository expenseRepository;
+
+    public FinanceService(ExpenseRepository expenseRepository) {
+        this.expenseRepository = expenseRepository;
+    }
 
     public List<Expense> listExpenses() {
-        return expenses;
+        return expenseRepository.findAll();
+    }
+
+    public Expense registerExpense(Expense expense) {
+        expenseRepository.save(expense);
+        return expense;
     }
 
     public ExpenseSummary calculateSummary() {
+        List<Expense> expenses = expenseRepository.findAll();
+
         BigDecimal totalPlanned = expenses.stream()
             .map(Expense::getAmount)
             .reduce(BigDecimal.ZERO, BigDecimal::add);


### PR DESCRIPTION
## Summary
- replace the in-memory expense list with a CSV-backed repository that reads and writes organized data
- expose a validated DTO and POST endpoint so new expenses persist to the CSV file
- seed the application with an expenses.csv file and add validation dependencies

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68defe8789b48323941e9bfc218b65fa