### PR TITLE
Add front-end expense form and CSV integrations

### DIFF
--- a/src/main/resources/static/app.js
+++ b/src/main/resources/static/app.js
@@ -5,6 +5,44 @@ $(document).ready(function () {
       currency: 'BRL'
     }).format(value);
 
+  const showFormFeedback = (message, type) => {
+    const feedback = $('#formFeedback');
+    feedback.removeClass('success error');
+    if (!message) {
+      feedback.text('');
+      return;
+    }
+    feedback.addClass(type === 'success' ? 'success' : 'error');
+    feedback.text(message);
+  };
+
+  const parseDecimal = (value) => {
+    if (typeof value !== 'string') {
+      return Number.NaN;
+    }
+    const normalized = value.trim().replace(/\s/g, '').replace(',', '.');
+    if (normalized.length === 0) {
+      return Number.NaN;
+    }
+    return Number(normalized);
+  };
+
+  const toggleRemainingField = () => {
+    const remainingInput = $('#expenseRemaining');
+    if ($('#expensePaid').is(':checked')) {
+      remainingInput.val('0.00');
+      remainingInput.prop('disabled', true);
+    } else {
+      remainingInput.prop('disabled', false);
+      if (!remainingInput.val()) {
+        const amount = parseDecimal($('#expenseAmount').val());
+        if (!Number.isNaN(amount) && amount >= 0) {
+          remainingInput.val(amount.toFixed(2));
+        }
+      }
+    }
+  };
+
   const updateSummary = (summary) => {
     $('#plannedValue').text(formatCurrency(summary.totalPlanned));
     $('#paidValue').text(formatCurrency(summary.totalPaid));
@@ -71,11 +109,114 @@ $(document).ready(function () {
   };
 
   const loadDashboard = () => {
-    $.getJSON('/api/finance/summary', (data) => {
-      updateSummary(data.summary);
-      renderExpenses(data.expenses);
-      renderGoals(data.summary);
+    $.getJSON('/api/finance/summary')
+      .done((data) => {
+        showFormFeedback('', 'success');
+        updateSummary(data.summary);
+        renderExpenses(data.expenses);
+        renderGoals(data.summary);
+      })
+      .fail(() => {
+        showFormFeedback('Não foi possível carregar os dados do orçamento.', 'error');
+        const tbody = $('#expensesBody');
+        tbody.empty();
+        tbody.append('<tr><td colspan="5">Não foi possível carregar as despesas.</td></tr>');
+      });
+  };
+
+  const setupForm = () => {
+    $('#expensePaid').on('change', toggleRemainingField);
+
+    $('#expenseAmount').on('input', () => {
+      if (!$('#expensePaid').is(':checked')) {
+        const amount = parseDecimal($('#expenseAmount').val());
+        if (!Number.isNaN(amount) && amount >= 0) {
+          $('#expenseRemaining').val(amount.toFixed(2));
+        }
+      }
     });
+
+    $('#expenseForm').on('submit', function (event) {
+      event.preventDefault();
+
+      const description = $('#expenseDescription').val().trim();
+      const amount = parseDecimal($('#expenseAmount').val());
+      const dueDay = Number($('#expenseDueDay').val());
+      const paid = $('#expensePaid').is(':checked');
+      let remaining = parseDecimal($('#expenseRemaining').val());
+
+      if (!description) {
+        showFormFeedback('Informe uma descrição para a despesa.', 'error');
+        return;
+      }
+
+      if (Number.isNaN(amount) || amount <= 0) {
+        showFormFeedback('Informe um valor válido maior que zero.', 'error');
+        return;
+      }
+
+      if (!Number.isInteger(dueDay) || dueDay < 1 || dueDay > 31) {
+        showFormFeedback('O dia de vencimento deve estar entre 1 e 31.', 'error');
+        return;
+      }
+
+      if (paid) {
+        remaining = 0;
+      } else if (Number.isNaN(remaining) || remaining < 0) {
+        showFormFeedback('Informe um valor restante válido.', 'error');
+        return;
+      }
+
+      const payload = {
+        paid,
+        description,
+        amount: Number(amount.toFixed(2)),
+        dueDay,
+        remaining: Number(remaining.toFixed(2))
+      };
+
+      $.ajax({
+        url: '/api/finance/expenses',
+        method: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify(payload)
+      })
+        .done(() => {
+          showFormFeedback('Despesa cadastrada com sucesso!', 'success');
+          event.target.reset();
+          $('#expenseRemaining').prop('disabled', false).val('');
+          toggleRemainingField();
+          loadDashboard();
+        })
+        .fail((xhr) => {
+          let message = 'Não foi possível cadastrar a despesa. Tente novamente.';
+          const response = xhr.responseJSON;
+          if (response) {
+            if (Array.isArray(response.errors) && response.errors.length > 0) {
+              message = response.errors.join(', ');
+            } else if (response.errors && typeof response.errors === 'object') {
+              const errorMessages = Object.values(response.errors)
+                .reduce((accumulator, value) => {
+                  if (Array.isArray(value)) {
+                    return accumulator.concat(value);
+                  }
+                  if (value) {
+                    accumulator.push(value);
+                  }
+                  return accumulator;
+                }, []);
+              if (errorMessages.length > 0) {
+                message = errorMessages.join(', ');
+              }
+            } else if (response.message) {
+              message = response.message;
+            }
+          }
+          showFormFeedback(message, 'error');
+        });
+    });
+
+    toggleRemainingField();
   };
 
   $('.nav-links a').on('click', function (event) {
@@ -93,5 +234,6 @@ $(document).ready(function () {
     );
   });
 
+  setupForm();
   loadDashboard();
 });

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -56,6 +56,42 @@
     </section>
 
     <section id="expenses" style="margin-top: 40px;">
+      <div class="form-card">
+        <h2 class="section-title">Cadastrar nova despesa</h2>
+        <p class="form-helper">Informe os dados abaixo para registrar uma nova despesa fixa no controle.</p>
+        <form id="expenseForm" novalidate>
+          <div class="form-grid">
+            <div class="form-group">
+              <label for="expenseDescription">Descrição</label>
+              <input type="text" id="expenseDescription" name="description" placeholder="Ex.: Aluguel do escritório" required>
+            </div>
+            <div class="form-group">
+              <label for="expenseAmount">Valor</label>
+              <input type="number" id="expenseAmount" name="amount" step="0.01" min="0" placeholder="0,00" required>
+            </div>
+            <div class="form-group">
+              <label for="expenseDueDay">Dia de vencimento</label>
+              <input type="number" id="expenseDueDay" name="dueDay" min="1" max="31" placeholder="Ex.: 15" required>
+            </div>
+            <div class="form-group">
+              <label for="expenseRemaining">Valor restante</label>
+              <input type="number" id="expenseRemaining" name="remaining" step="0.01" min="0" placeholder="0,00" required>
+            </div>
+            <div class="form-group checkbox-group">
+              <label for="expensePaid">Status de pagamento</label>
+              <div class="checkbox-wrapper">
+                <input type="checkbox" id="expensePaid" name="paid">
+                <span>Despesa já paga</span>
+              </div>
+            </div>
+          </div>
+          <div class="form-actions">
+            <button type="submit">Adicionar despesa</button>
+            <span id="formFeedback" class="form-feedback" role="status" aria-live="polite"></span>
+          </div>
+        </form>
+      </div>
+
       <div class="table-wrapper">
         <h2 class="section-title">Despesas fixas do mês</h2>
         <table>

--- a/src/main/resources/static/styles.css
+++ b/src/main/resources/static/styles.css
@@ -120,6 +120,109 @@ header h1 {
   overflow-x: auto;
 }
 
+.form-card {
+  background: var(--card-bg);
+  border-radius: 16px;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+  padding: 24px;
+  margin-bottom: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.form-helper {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-group label {
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+.form-group input[type="text"],
+.form-group input[type="number"] {
+  border: 1px solid #d9def0;
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-group input[type="text"]:focus,
+.form-group input[type="number"]:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(47, 128, 237, 0.15);
+}
+
+.checkbox-group {
+  align-self: flex-start;
+}
+
+.checkbox-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #f5f7ff;
+  border-radius: 12px;
+  padding: 12px 16px;
+}
+
+.checkbox-wrapper input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--primary);
+}
+
+.form-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.form-actions button {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 12px 28px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.form-actions button:hover {
+  background: var(--primary-dark);
+  transform: translateY(-1px);
+}
+
+.form-feedback {
+  font-size: 0.9rem;
+}
+
+.form-feedback.success {
+  color: var(--success);
+}
+
+.form-feedback.error {
+  color: #d63649;
+}
+
 .table-wrapper h2 {
   margin-bottom: 16px;
 }


### PR DESCRIPTION
## Summary
- add a new expense registration form to the dashboard so users can persist entries into the CSV-backed API
- enhance dashboard styles to accommodate the form and provide success/error feedback messaging
- extend the JavaScript to load summary data from the API, validate inputs, and post expenses back to the backend

## Testing
- ./mvnw -q test

------
https://chatgpt.com/codex/tasks/task_e_68df00734a188323b02e8ca8a8d38700