### PR TITLE
Enable cross-origin access and make API base configurable

### DIFF
--- a/src/main/java/com/finance/dashboard/controller/FinanceController.java
+++ b/src/main/java/com/finance/dashboard/controller/FinanceController.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@CrossOrigin(origins = "*")
 @RequestMapping("/api/finance")
 public class FinanceController {
 

--- a/src/main/resources/static/app.js
+++ b/src/main/resources/static/app.js
@@ -1,4 +1,35 @@
 $(document).ready(function () {
+  const DEFAULT_API_PORT = '8080';
+
+  const normalizeBaseUrl = (value) => {
+    if (!value || typeof value !== 'string') {
+      return '';
+    }
+    return value.endsWith('/') ? value.slice(0, -1) : value;
+  };
+
+  const resolveApiBaseUrl = () => {
+    if (typeof window.API_BASE_URL === 'string' && window.API_BASE_URL.trim().length > 0) {
+      return normalizeBaseUrl(window.API_BASE_URL.trim());
+    }
+
+    const { protocol, hostname, port } = window.location;
+
+    if (protocol === 'file:') {
+      return `http://localhost:${DEFAULT_API_PORT}`;
+    }
+
+    const isLocalhost = hostname === 'localhost' || hostname === '127.0.0.1';
+    if (isLocalhost && port && port !== DEFAULT_API_PORT) {
+      return `${protocol}//${hostname}:${DEFAULT_API_PORT}`;
+    }
+
+    return '';
+  };
+
+  const apiBaseUrl = resolveApiBaseUrl();
+  const apiUrl = (path) => `${apiBaseUrl}${path}`;
+
   const formatCurrency = (value) =>
     new Intl.NumberFormat('pt-BR', {
       style: 'currency',
@@ -109,7 +140,7 @@ $(document).ready(function () {
   };
 
   const loadDashboard = () => {
-    $.getJSON('/api/finance/summary')
+    $.getJSON(apiUrl('/api/finance/summary'))
       .done((data) => {
         showFormFeedback('', 'success');
         updateSummary(data.summary);
@@ -176,7 +207,7 @@ $(document).ready(function () {
       };
 
       $.ajax({
-        url: '/api/finance/expenses',
+        url: apiUrl('/api/finance/expenses'),
         method: 'POST',
         contentType: 'application/json',
         data: JSON.stringify(payload)


### PR DESCRIPTION
## Summary
- allow the finance API controller to respond to cross-origin requests so front-ends hosted on other origins can reach it
- update the dashboard script to resolve an API base URL dynamically (with an optional override) so requests point to the running backend even when the UI is served from a different port or via file://

## Testing
- ./mvnw -q test

------
https://chatgpt.com/codex/tasks/task_e_68df17f2ec6883239055762c2e264a35