### PR TITLE
Include expenses list in summary response

### DIFF
--- a/src/main/java/com/finance/dashboard/controller/FinanceController.java
+++ b/src/main/java/com/finance/dashboard/controller/FinanceController.java
@@ -3,6 +3,7 @@ package com.finance.dashboard.controller;
 import com.finance.dashboard.model.Expense;
 import com.finance.dashboard.model.ExpenseRequest;
 import com.finance.dashboard.model.ExpenseSummary;
+import com.finance.dashboard.model.ExpenseSummaryResponse;
 import com.finance.dashboard.service.FinanceService;
 import java.util.HashMap;
 import java.util.List;
@@ -41,10 +42,13 @@ public class FinanceController {
 
     @GetMapping("/summary")
     public Map<String, Object> getSummary() {
-        ExpenseSummary summary = financeService.calculateSummary();
+        List<Expense> expenses = financeService.listExpenses();
+        ExpenseSummary summary = financeService.calculateSummary(expenses);
+        ExpenseSummaryResponse response = ExpenseSummaryResponse.from(summary, expenses);
+
         Map<String, Object> payload = new HashMap<>();
-        payload.put("summary", summary);
-        payload.put("expenses", financeService.listExpenses());
+        payload.put("summary", response);
+        payload.put("expenses", expenses);
         return payload;
     }
 }

--- a/src/main/java/com/finance/dashboard/model/ExpenseSummaryResponse.java
+++ b/src/main/java/com/finance/dashboard/model/ExpenseSummaryResponse.java
@@ -1,0 +1,20 @@
+package com.finance.dashboard.model;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record ExpenseSummaryResponse(
+    BigDecimal totalPlanned,
+    BigDecimal totalPaid,
+    BigDecimal totalRemaining,
+    List<Expense> expenses
+) {
+    public static ExpenseSummaryResponse from(ExpenseSummary summary, List<Expense> expenses) {
+        return new ExpenseSummaryResponse(
+            summary.getTotalPlanned(),
+            summary.getTotalPaid(),
+            summary.getTotalRemaining(),
+            List.copyOf(expenses)
+        );
+    }
+}

--- a/src/main/java/com/finance/dashboard/service/FinanceService.java
+++ b/src/main/java/com/finance/dashboard/service/FinanceService.java
@@ -28,7 +28,10 @@ public class FinanceService {
 
     public ExpenseSummary calculateSummary() {
         List<Expense> expenses = expenseRepository.findAll();
+        return calculateSummary(expenses);
+    }
 
+    public ExpenseSummary calculateSummary(List<Expense> expenses) {
         BigDecimal totalPlanned = expenses.stream()
             .map(Expense::getAmount)
             .reduce(BigDecimal.ZERO, BigDecimal::add);


### PR DESCRIPTION
## Summary
- add an `ExpenseSummaryResponse` DTO that embeds the expense list alongside the totals
- reuse the loaded expenses when building the summary to avoid double reads
- return the enriched summary while keeping the existing `expenses` array for compatibility

## Testing
- ./mvnw -q test

------
https://chatgpt.com/codex/tasks/task_e_68df1a535d90832383ef0b3b7f71f037